### PR TITLE
添加BCTextPacketHelper以修复 #33

### DIFF
--- a/ZMusic-Plugin/src/main/java/me/zhenxin/zmusic/api/bossbar/BossBarBC.java
+++ b/ZMusic-Plugin/src/main/java/me/zhenxin/zmusic/api/bossbar/BossBarBC.java
@@ -2,15 +2,14 @@ package me.zhenxin.zmusic.api.bossbar;
 
 import com.google.common.collect.Sets;
 import me.zhenxin.zmusic.ZMusic;
+import me.zhenxin.zmusic.utils.BCTextPacketHelper;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.chat.ComponentSerializer;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 public class BossBarBC implements BossBar {
 
@@ -24,14 +23,14 @@ public class BossBarBC implements BossBar {
     private double progress = 0;
     private BarColor barColor;
     private BarStyle barStyle;
-    private String compiledTitle;
+    private TextComponent compiledTitle;
     private boolean visible = false;
 
     public BossBarBC(Object palyer, String title, BarColor barColor, BarStyle barStyle, float seconds) {
         this.uuid = UUID.nameUUIDFromBytes(("BBB:" + barID.getAndIncrement()).getBytes(StandardCharsets.UTF_8));
         this.player = palyer;
         this.title = title;
-        this.compiledTitle = ComponentSerializer.toString(new TextComponent(this.title));
+        this.compiledTitle = new TextComponent(this.title);
         this.barColor = barColor;
         this.barStyle = barStyle;
         this.seconds = seconds;
@@ -66,11 +65,12 @@ public class BossBarBC implements BossBar {
     @Override
     public void setTitle(String title) {
         this.title = title;
-        this.compiledTitle = ComponentSerializer.toString(new TextComponent(this.title));
+        this.compiledTitle = new TextComponent(this.title);
 
         if (visible) {
             net.md_5.bungee.protocol.packet.BossBar packet = new net.md_5.bungee.protocol.packet.BossBar(uuid, 3);
-            packet.setTitle(this.compiledTitle);
+            //packet.setTitle(this.compiledTitle);
+            BCTextPacketHelper.setTitle(this.compiledTitle, packet);
             this.players.forEach(player -> player.unsafe().sendPacket(packet));
         }
     }
@@ -153,7 +153,7 @@ public class BossBarBC implements BossBar {
 
     @Override
     public void removeAll() {
-        this.players.stream().collect(Collectors.toSet()).forEach(this::removePlayer);
+        this.players.forEach(this::removePlayer);
     }
 
     @Override
@@ -175,7 +175,8 @@ public class BossBarBC implements BossBar {
 
     private net.md_5.bungee.protocol.packet.BossBar getAddPacket() {
         net.md_5.bungee.protocol.packet.BossBar packet = new net.md_5.bungee.protocol.packet.BossBar(uuid, 0);
-        packet.setTitle(this.compiledTitle);
+        BCTextPacketHelper.setTitle(this.compiledTitle, packet);
+        //packet.setTitle(this.compiledTitle);
         packet.setColor(this.barColor.ordinal());
         packet.setDivision(this.barStyle.ordinal());
         packet.setHealth((float) this.progress);

--- a/ZMusic-Plugin/src/main/java/me/zhenxin/zmusic/utils/BCTextPacketHelper.java
+++ b/ZMusic-Plugin/src/main/java/me/zhenxin/zmusic/utils/BCTextPacketHelper.java
@@ -1,0 +1,47 @@
+package me.zhenxin.zmusic.utils;
+
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
+import net.md_5.bungee.protocol.packet.BossBar;
+import net.md_5.bungee.protocol.packet.Kick;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class BCTextPacketHelper {
+
+    private static final Class<BossBar> bossBarClass = BossBar.class;
+    private static final Method bossBarSetTitle;
+
+    private static final boolean isLegacy;
+
+    static {
+        boolean a = false;
+        try {
+            Kick.class.getConstructor(String.class).newInstance("");
+            a=true;
+        } catch (Exception ignore) {}
+        isLegacy=a;
+
+        try {
+            bossBarSetTitle = bossBarClass.getMethod("setTitle", a ? String.class : BaseComponent.class);
+        } catch (NoSuchMethodException e) {
+            throw new FailedProcessPacketException("BossBar.setTitle", e);
+        }
+    }
+
+    public static void setTitle(final BaseComponent component, final BossBar packet) {
+        try {
+            bossBarSetTitle.invoke(packet, isLegacy ? ComponentSerializer.toString(component) : component);
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            throw new FailedProcessPacketException("BossBar.setTitle", e);
+        }
+    }
+
+    private static class FailedProcessPacketException extends RuntimeException {
+        private FailedProcessPacketException(final String fieldName, final Throwable throwable) {
+            super("A exception has occurred when getting field: " + fieldName, throwable);
+        }
+    }
+
+}


### PR DESCRIPTION
Close #33 

在为了保持与较旧的BungeeCord兼容性的情况下 反射可能是最好的选择.
已使用字段来存储对应的方法 所以性能应该不是一个很大的问题

![image](https://github.com/RealHeart/ZMusic/assets/71176602/03e5714c-53a7-428e-9d9b-b2383bca3059)
![image](https://github.com/RealHeart/ZMusic/assets/71176602/6c7f40af-1a71-452d-9676-6b971df9b9a1)
