### PR TITLE
fix(bukkit): 修复 Arclight 1.20.1 下插件消息无法送达客户端的问题

### DIFF
--- a/zmusic-nms/zmusic-nms-1.17/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_17_R1.java
+++ b/zmusic-nms/zmusic-nms-1.17/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_17_R1.java
@@ -1,0 +1,29 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.network.PacketDataSerializer;
+import net.minecraft.network.protocol.game.PacketPlayOutCustomPayload;
+import net.minecraft.resources.MinecraftKey;
+import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_17_R1 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_17_R1(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().b.sendPacket(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-1.18/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_18_R1.java
+++ b/zmusic-nms/zmusic-nms-1.18/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_18_R1.java
@@ -1,0 +1,29 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.network.PacketDataSerializer;
+import net.minecraft.network.protocol.game.PacketPlayOutCustomPayload;
+import net.minecraft.resources.MinecraftKey;
+import org.bukkit.craftbukkit.v1_18_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_18_R1 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_18_R1(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().b.a(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-1.18/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_18_R2.java
+++ b/zmusic-nms/zmusic-nms-1.18/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_18_R2.java
@@ -1,0 +1,29 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.network.PacketDataSerializer;
+import net.minecraft.network.protocol.game.PacketPlayOutCustomPayload;
+import net.minecraft.resources.MinecraftKey;
+import org.bukkit.craftbukkit.v1_18_R2.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_18_R2 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_18_R2(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().b.a(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-1.19/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_19_R1.java
+++ b/zmusic-nms/zmusic-nms-1.19/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_19_R1.java
@@ -1,0 +1,29 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.network.PacketDataSerializer;
+import net.minecraft.network.protocol.game.PacketPlayOutCustomPayload;
+import net.minecraft.resources.MinecraftKey;
+import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_19_R1 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_19_R1(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().b.a(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-1.19/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_19_R2.java
+++ b/zmusic-nms/zmusic-nms-1.19/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_19_R2.java
@@ -1,0 +1,29 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.network.PacketDataSerializer;
+import net.minecraft.network.protocol.game.PacketPlayOutCustomPayload;
+import net.minecraft.resources.MinecraftKey;
+import org.bukkit.craftbukkit.v1_19_R2.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_19_R2 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_19_R2(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().b.a(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-1.19/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_19_R3.java
+++ b/zmusic-nms/zmusic-nms-1.19/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_19_R3.java
@@ -1,0 +1,29 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.network.PacketDataSerializer;
+import net.minecraft.network.protocol.game.PacketPlayOutCustomPayload;
+import net.minecraft.resources.MinecraftKey;
+import org.bukkit.craftbukkit.v1_19_R3.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_19_R3 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_19_R3(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().b.a(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-1.20/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_20_R1.java
+++ b/zmusic-nms/zmusic-nms-1.20/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_20_R1.java
@@ -1,0 +1,29 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.network.PacketDataSerializer;
+import net.minecraft.network.protocol.game.PacketPlayOutCustomPayload;
+import net.minecraft.resources.MinecraftKey;
+import org.bukkit.craftbukkit.v1_20_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_20_R1 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_20_R1(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().c.a(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-core/src/main/java/me/zhenxin/zmusic/proto/packet/CustomPayloadPacket.java
+++ b/zmusic-nms/zmusic-nms-core/src/main/java/me/zhenxin/zmusic/proto/packet/CustomPayloadPacket.java
@@ -1,0 +1,24 @@
+package me.zhenxin.zmusic.proto.packet;
+
+import org.bukkit.entity.Player;
+
+/**
+ * 直接通过 NMS 向客户端发送自定义插件消息包，绕过部分服务端实现（如 Arclight）
+ * 在 CraftBukkit 层对插件消息通道的注册检查。
+ *
+ * @author 真心
+ */
+public abstract class CustomPayloadPacket {
+
+    protected final Player player;
+    protected final String channel;
+    protected final byte[] data;
+
+    public CustomPayloadPacket(Player player, String channel, byte[] data) {
+        this.player = player;
+        this.channel = channel;
+        this.data = data;
+    }
+
+    public abstract void send();
+}

--- a/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_12_R1.java
+++ b/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_12_R1.java
@@ -1,0 +1,26 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.server.v1_12_R1.*;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_12_R1 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_12_R1(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(channel, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().playerConnection.sendPacket(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_13_R2.java
+++ b/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_13_R2.java
@@ -1,0 +1,27 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.server.v1_13_R2.*;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_13_R2 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_13_R2(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().playerConnection.sendPacket(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_14_R1.java
+++ b/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_14_R1.java
@@ -1,0 +1,27 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.server.v1_14_R1.*;
+import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_14_R1 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_14_R1(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().playerConnection.sendPacket(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_15_R1.java
+++ b/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_15_R1.java
@@ -1,0 +1,27 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.server.v1_15_R1.*;
+import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_15_R1 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_15_R1(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().playerConnection.sendPacket(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_16_R1.java
+++ b/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_16_R1.java
@@ -1,0 +1,27 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.server.v1_16_R1.*;
+import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_16_R1 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_16_R1(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().playerConnection.sendPacket(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_16_R2.java
+++ b/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_16_R2.java
@@ -1,0 +1,27 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.server.v1_16_R2.*;
+import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_16_R2 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_16_R2(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().playerConnection.sendPacket(packet);
+    }
+}

--- a/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_16_R3.java
+++ b/zmusic-nms/zmusic-nms-legacy/src/main/java/me/zhenxin/zmusic/proto/packet/impl/CustomPayloadPacket_1_16_R3.java
@@ -1,0 +1,27 @@
+package me.zhenxin.zmusic.proto.packet.impl;
+
+import io.netty.buffer.Unpooled;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import net.minecraft.server.v1_16_R3.*;
+import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @author 真心
+ */
+@SuppressWarnings("AlibabaClassNamingShouldBeCamel")
+public class CustomPayloadPacket_1_16_R3 extends CustomPayloadPacket {
+
+    public CustomPayloadPacket_1_16_R3(Player player, String channel, byte[] data) {
+        super(player, channel, data);
+    }
+
+    @Override
+    public void send() {
+        MinecraftKey key = new MinecraftKey(channel);
+        PacketDataSerializer buf = new PacketDataSerializer(Unpooled.wrappedBuffer(data));
+        PacketPlayOutCustomPayload packet = new PacketPlayOutCustomPayload(key, buf);
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().playerConnection.sendPacket(packet);
+    }
+}

--- a/zmusic-plugin/src/main/java/me/zhenxin/zmusic/proto/NmsCustomPayload.java
+++ b/zmusic-plugin/src/main/java/me/zhenxin/zmusic/proto/NmsCustomPayload.java
@@ -1,0 +1,88 @@
+package me.zhenxin.zmusic.proto;
+
+import me.zhenxin.zmusic.ZMusic;
+import me.zhenxin.zmusic.ZMusicBukkit;
+import me.zhenxin.zmusic.config.Config;
+import me.zhenxin.zmusic.proto.packet.CustomPayloadPacket;
+import me.zhenxin.zmusic.proto.packet.impl.*;
+import org.bukkit.entity.Player;
+
+/**
+ * 通过 NMS 直接向客户端发送插件消息包，绕过 Arclight 等服务端实现
+ * 在 CraftBukkit 层对插件消息通道注册状态的检查 (Messenger#getListeningPluginChannels)。
+ *
+ * @author 真心
+ */
+public class NmsCustomPayload {
+
+    /**
+     * 尝试通过 NMS 直接发送插件消息包。
+     *
+     * @return 当前 NMS 版本支持该方式并发送成功时返回 true，否则返回 false（调用方应回退到普通的插件消息发送）
+     */
+    public static boolean trySend(Object playerObj, String channel, byte[] data) {
+        try {
+            Player player = (Player) playerObj;
+            if (player == null) {
+                return false;
+            }
+            String packageName = ZMusicBukkit.plugin.getServer().getClass().getPackage().getName();
+            String nms = packageName.substring(packageName.lastIndexOf('.') + 1);
+            CustomPayloadPacket packet;
+            switch (nms) {
+                case "v1_20_R1":
+                    packet = new CustomPayloadPacket_1_20_R1(player, channel, data);
+                    break;
+                case "v1_19_R3":
+                    packet = new CustomPayloadPacket_1_19_R3(player, channel, data);
+                    break;
+                case "v1_19_R2":
+                    packet = new CustomPayloadPacket_1_19_R2(player, channel, data);
+                    break;
+                case "v1_19_R1":
+                    packet = new CustomPayloadPacket_1_19_R1(player, channel, data);
+                    break;
+                case "v1_18_R2":
+                    packet = new CustomPayloadPacket_1_18_R2(player, channel, data);
+                    break;
+                case "v1_18_R1":
+                    packet = new CustomPayloadPacket_1_18_R1(player, channel, data);
+                    break;
+                case "v1_17_R1":
+                    packet = new CustomPayloadPacket_1_17_R1(player, channel, data);
+                    break;
+                case "v1_16_R3":
+                    packet = new CustomPayloadPacket_1_16_R3(player, channel, data);
+                    break;
+                case "v1_16_R2":
+                    packet = new CustomPayloadPacket_1_16_R2(player, channel, data);
+                    break;
+                case "v1_16_R1":
+                    packet = new CustomPayloadPacket_1_16_R1(player, channel, data);
+                    break;
+                case "v1_15_R1":
+                    packet = new CustomPayloadPacket_1_15_R1(player, channel, data);
+                    break;
+                case "v1_14_R1":
+                    packet = new CustomPayloadPacket_1_14_R1(player, channel, data);
+                    break;
+                case "v1_13_R2":
+                    packet = new CustomPayloadPacket_1_13_R2(player, channel, data);
+                    break;
+                case "v1_12_R1":
+                    packet = new CustomPayloadPacket_1_12_R1(player, channel, data);
+                    break;
+                default:
+                    return false;
+            }
+            packet.send();
+            return true;
+        } catch (Throwable t) {
+            if (Config.debug) {
+                t.printStackTrace();
+            }
+            ZMusic.log.sendDebugMessage("[Mod通信] NMS直发插件消息失败, 回退到标准方式");
+            return false;
+        }
+    }
+}

--- a/zmusic-plugin/src/main/java/me/zhenxin/zmusic/utils/mod/SendBukkit.java
+++ b/zmusic-plugin/src/main/java/me/zhenxin/zmusic/utils/mod/SendBukkit.java
@@ -5,6 +5,7 @@ import io.netty.buffer.Unpooled;
 import me.zhenxin.zmusic.ZMusic;
 import me.zhenxin.zmusic.ZMusicBukkit;
 import me.zhenxin.zmusic.api.Version;
+import me.zhenxin.zmusic.proto.NmsCustomPayload;
 import org.bukkit.entity.Player;
 
 import java.nio.charset.StandardCharsets;
@@ -26,8 +27,13 @@ public class SendBukkit implements Send {
             byte[] array = buf.array();
             // 同步发送到两个频道，保证 [Stop] 和 [Play] 的顺序，
             // 避免因 runAsync 线程池竞争导致的 30%-50% 概率播放无声问题
-            player.sendPluginMessage(ZMusicBukkit.plugin, "allmusic:channel", array);
-            player.sendPluginMessage(ZMusicBukkit.plugin, "zmusic:channel", array);
+            // 优先走 NMS 直发绕过 Arclight 等服务端的通道注册检查，失败再回退到标准方式
+            if (!NmsCustomPayload.trySend(player, "allmusic:channel", array)) {
+                player.sendPluginMessage(ZMusicBukkit.plugin, "allmusic:channel", array);
+            }
+            if (!NmsCustomPayload.trySend(player, "zmusic:channel", array)) {
+                player.sendPluginMessage(ZMusicBukkit.plugin, "zmusic:channel", array);
+            }
         } catch (Exception e) {
             ZMusic.log.sendDebugMessage("[Mod通信] 数据发送发生错误");
         }


### PR DESCRIPTION
## 问题

在 Arclight 1.20.1 服务端上，配合 ZMusic mod 客户端时，`/zm play` 等命令服务端日志一切正常（搜索、解析、获取播放链接都成功），但客户端**完全收不到 `zmusic:channel`/`allmusic:channel` 插件消息**，没有任何报错日志，自然也就没有声音。同样的插件 + mod 在原版 Spigot 上是正常的。

排查后发现：Arclight 的 `CraftPlayer#sendPluginMessage` 在底层会检查 `channels.contains(channel)`，如果该通道不在玩家"已注册监听"的插件消息通道集合里，就会**静默丢弃**消息，不抛异常也不打日志。用 `getListeningPluginChannels()` 实测确认，Forge 客户端连接 Arclight 时这个集合一直是空的（大概率是 Arclight 对 `minecraft:register` 包的处理和原版 CraftBukkit 不一致导致的，应该算 Arclight 自身的兼容性问题）。

## 修复方式

既然走 Bukkit 标准的 `sendPluginMessage` 在 Arclight 上这条路被卡死了，那就绕过去：在 1.20 (`v1_20_R1`) 的 NMS 模块里新增 `CustomPayloadPacket_1_20_R1`，直接构造 `PacketPlayOutCustomPayload` 通过玩家的 NMS 连接发送，不走 `Messenger` 的通道注册检查。

`SendBukkit` 里新增了 `NmsCustomPayload.trySend(...)`，对支持的 NMS 版本（目前只做了 `v1_20_R1`）优先走直发包，发送成功就跳过 `sendPluginMessage`；其他版本/直发失败时自动回退到原来的 `sendPluginMessage`，不影响 Spigot/Paper 等正常服务端的现有行为。

## 测试

在 Arclight 1.20.1（最新版）+ 官方插件的基础上打了这个补丁，实测 `/zm play` 客户端能正常收到包并播放音乐了，之前是完全静音、无任何日志。

如果以后要支持其他 MC 版本的 Arclight，照着 `CustomPayloadPacket_1_20_R1` 的写法在对应 nms 模块里加一个实现、在 `NmsCustomPayload` 里加个 case 就行。