### PR TITLE
fix: 修复播放音乐时有概率无声的问题 (~30%-50%)

### DIFF
--- a/zmusic-plugin/build.gradle
+++ b/zmusic-plugin/build.gradle
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.shadow)
 }
 
-version = '2.12.0'
+version = '2.12.1'
 
 dependencies {
     compileOnly 'ink.ptms:nms-all:1.0.0'

--- a/zmusic-plugin/src/main/java/me/zhenxin/zmusic/ZMusic.java
+++ b/zmusic-plugin/src/main/java/me/zhenxin/zmusic/ZMusic.java
@@ -31,7 +31,7 @@ public final class ZMusic {
 
     public static File dataFolder;
     public static String thisVer;
-    public static int thisVerCode = 202605120;
+    public static int thisVerCode = 202606220;
     public static boolean isVip = false;
     public static boolean isViaVer = true;
     public static boolean isEnable = true;
@@ -42,13 +42,12 @@ public final class ZMusic {
         List<Object> players = ZMusic.player.getOnlinePlayerList();
         if (!players.isEmpty()) {
             for (Object player : players) {
-                OtherUtils.resetPlayerStatus(player);
                 PlayListPlayer plp = PlayerData.getPlayerPlayListPlayer(player);
                 if (plp != null) {
                     plp.isStop = true;
                     PlayerData.setPlayerPlayListPlayer(player, null);
-                    OtherUtils.resetPlayerStatus(player);
                 }
+                OtherUtils.resetPlayerStatus(player);
             }
         }
         ZMusic.log.sendNormalMessage("插件作者: 真心");

--- a/zmusic-plugin/src/main/java/me/zhenxin/zmusic/ZMusicVelocity.java
+++ b/zmusic-plugin/src/main/java/me/zhenxin/zmusic/ZMusicVelocity.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 @Plugin(
         id = "zmusic",
         name = "ZMusic",
-        version = "2.12.0",
+        version = "2.12.1",
         description = "A Minecraft music plugin supporting Bukkit, BungeeCord, and Velocity",
         url = "https://github.com/zhenxin/ZMusic",
         authors = {"ZhenXin"}
@@ -68,7 +68,7 @@ public class ZMusicVelocity {
             ZMusic.dataFolder.mkdir();
         }
         Config.debug = true;
-        ZMusic.thisVer = "2.12.0";
+        ZMusic.thisVer = "2.12.1";
         ZMusic.log.sendNormalMessage("正在加载中....");
         CookieUtils.initCookieManager();
 

--- a/zmusic-plugin/src/main/java/me/zhenxin/zmusic/command/Cmd.java
+++ b/zmusic-plugin/src/main/java/me/zhenxin/zmusic/command/Cmd.java
@@ -285,7 +285,6 @@ public class Cmd {
             if (plp != null) {
                 plp.isStop = true;
                 PlayerData.setPlayerPlayListPlayer(sender, null);
-                OtherUtils.resetPlayerStatus(sender);
             }
             OtherUtils.resetPlayerStatus(sender);
             ZMusic.message.sendNormalMessage("停止播放音乐成功!", sender);

--- a/zmusic-plugin/src/main/java/me/zhenxin/zmusic/utils/mod/SendBC.java
+++ b/zmusic-plugin/src/main/java/me/zhenxin/zmusic/utils/mod/SendBC.java
@@ -19,8 +19,11 @@ public class SendBC implements Send {
             ByteBuf buf = Unpooled.buffer(bytes.length + 1);
             buf.writeByte(666);
             buf.writeBytes(bytes);
-            ZMusic.runTask.runAsync(() -> player.sendData("allmusic:channel", buf.array()));
-            ZMusic.runTask.runAsync(() -> player.sendData("zmusic:channel", buf.array()));
+            byte[] array = buf.array();
+            // 同步发送到两个频道，保证 [Stop] 和 [Play] 的顺序，
+            // 避免因 runAsync 线程池竞争导致的播放无声问题
+            player.sendData("allmusic:channel", array);
+            player.sendData("zmusic:channel", array);
         } catch (
             Exception e) {
             ZMusic.log.sendDebugMessage("[Mod通信] 数据发送发生错误");

--- a/zmusic-plugin/src/main/java/me/zhenxin/zmusic/utils/mod/SendBukkit.java
+++ b/zmusic-plugin/src/main/java/me/zhenxin/zmusic/utils/mod/SendBukkit.java
@@ -23,8 +23,11 @@ public class SendBukkit implements Send {
             ByteBuf buf = Unpooled.buffer(bytes.length + 1);
             buf.writeByte(666);
             buf.writeBytes(bytes);
-            ZMusic.runTask.runAsync(() -> player.sendPluginMessage(ZMusicBukkit.plugin, "allmusic:channel", buf.array()));
-            ZMusic.runTask.runAsync(() -> player.sendPluginMessage(ZMusicBukkit.plugin, "zmusic:channel", buf.array()));
+            byte[] array = buf.array();
+            // 同步发送到两个频道，保证 [Stop] 和 [Play] 的顺序，
+            // 避免因 runAsync 线程池竞争导致的 30%-50% 概率播放无声问题
+            player.sendPluginMessage(ZMusicBukkit.plugin, "allmusic:channel", array);
+            player.sendPluginMessage(ZMusicBukkit.plugin, "zmusic:channel", array);
         } catch (Exception e) {
             ZMusic.log.sendDebugMessage("[Mod通信] 数据发送发生错误");
         }


### PR DESCRIPTION
## 问题描述

玩家使用点歌指令时，约 30%-50% 的概率播放无声。无声/有声在播放启动瞬间决定，中途不会变化。

## 根因分析

`SendBukkit.sendAM()` 和 `SendBC.sendAM()` 中，每条消息通过两个独立的 `runAsync()` 分别发送到 `allmusic:channel` 和 `zmusic:channel`：

当播放音乐时，`[Stop]` 和 `[Play]` 先后调用 `sendAM()`，提交了 4 个异步任务到 ForkJoinPool。由于线程池不保证 FIFO 顺序，约 50% 概率 `[Play]` 的异步任务先于 `[Stop]` 的任务执行，导致客户端先收到 `[Play]` 再收到 `[Stop]`，播放被立即终止。

- 正常：`[Stop]` -> `[Play]`  有声
- 异常：`[Play]` -> `[Stop]`  无声（~50%）

## 修复内容

1. `SendBukkit.java` / `SendBC.java`（根因修复）：将 `sendAM()` 中的两个独立 `runAsync` 合并为同步顺序发送，保证 `[Stop]` 和 `[Play]` 的到达顺序与调用顺序一致
2. `Cmd.java`：移除 `handleStopCommand` 中重复的 `resetPlayerStatus()` 调用（避免发送两次 `[Stop]`）
3. `ZMusic.java`：移除 `disable()` 中重复的 `resetPlayerStatus()` 调用
4. 版本号：`2.12.0` -> `2.12.1`

## 测试方式

在安装了 ZMusic 的服务器上反复使用 `/zm music 163 <歌名>` 点歌，之前约 30%-50% 概率无声，修复后应每次都有声。
**以上内容以及代码为AI生成，本人已测试修复版可以正常点歌**
