### PR TITLE
fix: bossbar/title/hud disabled on calver servers & bossbar not thread-safe on folia

### DIFF
--- a/zmusic-plugin/src/main/java/me/zhenxin/zmusic/api/Version.java
+++ b/zmusic-plugin/src/main/java/me/zhenxin/zmusic/api/Version.java
@@ -14,26 +14,28 @@ public class Version {
 
     //比目标版本低
     public boolean isLowerThan(String ver) {
-        String[] versions = getVersion().split("\\.");
-        String[] vers = ver.split("\\.");
-        for (int i = 0; i <= (vers.length - 1); i++) {
-            if (Integer.parseInt(vers[i]) > Integer.parseInt(versions[i])) {
-                return true;
-            }
-        }
-        return false;
+        return compare(ver) < 0;
     }
 
     //比目标版本高
     public boolean isHigherThan(String ver) {
-        String[] versions = getVersion().split("\\.");
-        String[] vers = ver.split("\\.");
-        for (int i = 0; i <= (vers.length - 1); i++) {
-            if (Integer.parseInt(vers[i]) < Integer.parseInt(versions[i])) {
-                return true;
+        return compare(ver) > 0;
+    }
+
+    // 与目标版本比较: 负数=低于, 0=相等, 正数=高于
+    // 按点分段逐段比较，长度不足按 0 处理，兼容 CalVer (如 26.1.2) 与旧语义版本 (如 1.9)
+    private int compare(String ver) {
+        String[] cur = getVersion().split("\\.");
+        String[] target = ver.split("\\.");
+        int len = Math.max(cur.length, target.length);
+        for (int i = 0; i < len; i++) {
+            int c = i < cur.length ? Integer.parseInt(cur[i]) : 0;
+            int t = i < target.length ? Integer.parseInt(target[i]) : 0;
+            if (c != t) {
+                return c - t;
             }
         }
-        return false;
+        return 0;
     }
 
     //与目标版本相等

--- a/zmusic-plugin/src/main/java/me/zhenxin/zmusic/api/bossbar/BossBarBukkit.java
+++ b/zmusic-plugin/src/main/java/me/zhenxin/zmusic/api/bossbar/BossBarBukkit.java
@@ -1,9 +1,13 @@
 package me.zhenxin.zmusic.api.bossbar;
 
 import me.zhenxin.zmusic.ZMusic;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 
 public class BossBarBukkit implements BossBar {
@@ -12,6 +16,8 @@ public class BossBarBukkit implements BossBar {
     private final String title;
     private final double seconds;
     private final org.bukkit.boss.BossBar bar;
+    private Object foliaTask;
+    private BukkitTask bukkitTask;
 
     public BossBarBukkit(Object p, String title, BarColor color, BarStyle style, float seconds) {
         Player player = (Player) p;
@@ -26,21 +32,41 @@ public class BossBarBukkit implements BossBar {
         bar.setVisible(true);
         bar.setProgress(0);
         bar.addPlayer(p);
-        ZMusic.runTask.runAsync(() -> {
-            double step = 1F / seconds;
-            double prog = bar.getProgress();
-            while (prog >= 0 || prog <= 1) {
-                prog += step;
-                if (prog > 1) break;
-                bar.setProgress(prog);
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
+        // 同步定时器更新进度，避免在异步线程访问非线程安全的 BossBar
+        // 兼容 Folia: 反射调用 GlobalRegionScheduler.runAtFixedRate
+        Plugin plugin = ZMusicBukkitPlugin();
+        Runnable tick = () -> {
+            if (!bar.isVisible()) {
+                cancelTask();
+                return;
             }
-            bar.setVisible(false);
-        });
+            double step = 1F / seconds;
+            double prog = Math.min(bar.getProgress() + step, 1.0);
+            if (prog >= 1.0) {
+                bar.setProgress(1.0);
+                bar.setVisible(false);
+                cancelTask();
+                return;
+            }
+            bar.setProgress(prog);
+        };
+        if (ZMusic.isFolia) {
+            try {
+                Object scheduler = Bukkit.class.getMethod("getGlobalRegionScheduler").invoke(null);
+                java.lang.reflect.Method runAtFixedRate = scheduler.getClass().getMethod(
+                        "runAtFixedRate", Plugin.class, Consumer.class, long.class, long.class);
+                foliaTask = runAtFixedRate.invoke(scheduler, plugin, (Consumer<Object>) t -> tick.run(), 20L, 20L);
+            } catch (Exception e) {
+                // 反射失败回退到 Bukkit 调度器
+                bukkitTask = Bukkit.getServer().getScheduler().runTaskTimer(plugin, tick, 20L, 20L);
+            }
+        } else {
+            bukkitTask = Bukkit.getServer().getScheduler().runTaskTimer(plugin, tick, 20L, 20L);
+        }
+    }
+
+    private static Plugin ZMusicBukkitPlugin() {
+        return me.zhenxin.zmusic.ZMusicBukkit.plugin;
     }
 
     @Override
@@ -57,11 +83,13 @@ public class BossBarBukkit implements BossBar {
     public void removePlayer(Object player) {
         Player p = (Player) player;
         bar.removePlayer(p);
+        cancelTask();
     }
 
     @Override
     public void removeAll() {
         bar.removeAll();
+        cancelTask();
     }
 
     @Override
@@ -72,6 +100,23 @@ public class BossBarBukkit implements BossBar {
     @Override
     public void setVisible(boolean visible) {
         bar.setVisible(visible);
+        if (!visible) {
+            cancelTask();
+        }
+    }
+
+    private void cancelTask() {
+        if (bukkitTask != null) {
+            bukkitTask.cancel();
+            bukkitTask = null;
+        }
+        if (foliaTask != null) {
+            try {
+                foliaTask.getClass().getMethod("cancel").invoke(foliaTask);
+            } catch (Exception ignored) {
+            }
+            foliaTask = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Problem

On Purpur 26.1.2, ZMusic disables BossBar/Title/ActionBar/Hud/Advancement at startup:


## Root Cause

`Version.isLowerThan` / `isHigherThan` only compared segments up to the **target** version's length, with wrong early-return logic.

`26.1.2` vs `1.9`:
- `i=0`: `1 > 26`? false → continue
- `i=1`: `9 > 1`? true → return `isLowerThan=true` ❌

Additionally, `BossBarBukkit.showTitle()` updated progress on an async thread via `Thread.sleep`, which is not thread-safe and breaks on Folia.

## Fix

- `Version.java`: compare all segments with zero-padding, return on first difference. Correctly handles CalVer (`26.1.2`) vs legacy semver (`1.9`).
- `BossBarBukkit.java`: replace async thread + `Thread.sleep` with `runTaskTimer`; reflect `GlobalRegionScheduler.runAtFixedRate` on Folia; cancel task on `removePlayer`/`removeAll`/`setVisible(false)`.

## Test

- Server: Purpur 26.1.2
- BossBar/Title/Hud no longer disabled at startup
- BossBar progress updates correctly on main thread

(Orz)
